### PR TITLE
Observation csv cleanup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
 --require spec_helper
+--format d

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,6 +5,7 @@
 @import "font-awesome.min";
 @import "formbuilder-min";
 
+@import "observation";
 
 body {
   padding-top: 70px;

--- a/app/assets/stylesheets/observation.scss
+++ b/app/assets/stylesheets/observation.scss
@@ -1,0 +1,4 @@
+.panel-data {
+  overflow-x: auto;
+  margin: -15px;
+}

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1,12 +1,7 @@
 class ObservationsController < ApplicationController
 
   def index
-    # @by_protocol = SurveyProtocol.all.includes(:observations => :samples)
-    obs_by_site = Observation.order(:site_id).includes(:samples)
-    @by_site = Hash.new { |h, k| h[k] = [] }
-    obs_by_site.each do |observation|
-      @by_site[Site.find(observation.site_id).name] << observation
-    end
+    @by_protocol = SurveyProtocol.all.includes(:observations => :samples)
 
     respond_to do |format|
       format.html
@@ -47,11 +42,11 @@ class ObservationsController < ApplicationController
     end
   end
 
-  # hijacked RESTful show action to export CSV for an observation
+  # hijacked RESTful show action to export CSV for a protocol
   def show
-    @observation = Observation.find_by_id(params[:id])
+    protocol = SurveyProtocol.find_by_id(params[:id])
     respond_to do |format|
-      format.csv { send_data Observation.to_csv(@observation), filename: "observation-#{params[:id]}.csv" }
+      format.csv { send_data protocol.samples_to_csv, filename: "#{protocol.title}-#{protocol.id}.csv" }
     end
   end
 

--- a/app/controllers/observations_controller.rb
+++ b/app/controllers/observations_controller.rb
@@ -1,7 +1,7 @@
 class ObservationsController < ApplicationController
 
   def index
-    @by_protocol = SurveyProtocol.all.includes(:observations => :samples)
+    @protocols = SurveyProtocol.all.includes(:observations => :samples)
 
     respond_to do |format|
       format.html

--- a/app/models/observation.rb
+++ b/app/models/observation.rb
@@ -3,28 +3,8 @@ class Observation < ActiveRecord::Base
   belongs_to :site
   has_many :samples
 
-  # generates CSV with all samples for this observation
-  def self.to_csv(obs_by_site)
-
-    CSV.generate do |csv|
-      obs_by_site.each do |site, observations|
-        # site name
-        csv << [site]
-        # observations
-        observations.each do |observation|
-          csv << ["", "Observation", "#{observation.id}", "#{observation.date}"]
-          # samples
-          csv << ["", "", "Samples"]
-          observation.samples.each_with_index do |sample, i|
-            csv << ["", "", "id", "subsite_id"] + sample.response_data.keys if i == 0
-            csv << ["", "", "#{sample.id}", "#{sample.subsite.id}"] + sample.response_data.values
-          end
-        end
-      end
-    end
-  end
-
   def sample_field_names
     protocol.sample_fields.map {|field| field["label"]}
   end
+
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,6 +1,5 @@
 class Site < ActiveRecord::Base
   belongs_to :property
-
   has_many :subsites
 
   validates :name, presence: true

--- a/app/models/survey_protocol.rb
+++ b/app/models/survey_protocol.rb
@@ -12,7 +12,6 @@ class SurveyProtocol < ActiveRecord::Base
       # populate sample values
       observations.each do |observation|
         observation.samples.each do |sample|
-          binding.pry
           csv << [observation.site.name] + sample_headers.inject([]) do |m, k|
             m << sample.response_data[k]
             m

--- a/app/models/survey_protocol.rb
+++ b/app/models/survey_protocol.rb
@@ -1,3 +1,21 @@
 class SurveyProtocol < ActiveRecord::Base
   has_many :observations, foreign_key: :protocol_id
+
+  # generates CSV with all samples for this protocol
+  def samples_to_csv
+
+    CSV.generate do |csv|
+      # column headers
+      csv << ["site name"] + observations.first.samples.first.response_data.keys
+      observations = self.observations.includes(:samples)
+      # populate sample values
+      observations.each do |observation|
+        observation.samples.each do |sample|
+          csv << [observation.site.name] + sample.response_data.values
+        end
+      end
+    end
+
+  end
+
 end

--- a/app/models/survey_protocol.rb
+++ b/app/models/survey_protocol.rb
@@ -6,12 +6,17 @@ class SurveyProtocol < ActiveRecord::Base
 
     CSV.generate do |csv|
       # column headers
-      csv << ["site name"] + observations.first.samples.first.response_data.keys
+      sample_headers = observations.first.sample_field_names
+      csv << ["site name"] + sample_headers
       observations = self.observations.includes(:samples)
       # populate sample values
       observations.each do |observation|
         observation.samples.each do |sample|
-          csv << [observation.site.name] + sample.response_data.values
+          binding.pry
+          csv << [observation.site.name] + sample_headers.inject([]) do |m, k|
+            m << sample.response_data[k]
+            m
+          end
         end
       end
     end

--- a/app/views/observations/_samples_table.html.erb
+++ b/app/views/observations/_samples_table.html.erb
@@ -1,0 +1,24 @@
+<div class="table-responsive panel-data">
+  <% observations.each do |observation| %>
+    <table class="table table-striped table-bordered">
+      <!-- Column Headers -->
+      <thead>
+        <tr>
+          <% observation.samples.first.response_data.each do |k, v| %>
+            <th><%= k %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <!-- Populate Sample Values -->
+      <tbody>
+        <% observation.samples.each do |sample| %>
+          <tr>
+            <% sample.response_data.each do |k, v| %>
+              <td><%= v %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+</div>

--- a/app/views/observations/_samples_table.html.erb
+++ b/app/views/observations/_samples_table.html.erb
@@ -4,8 +4,8 @@
       <!-- Column Headers -->
       <thead>
         <tr>
-          <% observation.samples.first.response_data.each do |k, v| %>
-            <th><%= k %></th>
+          <% column_headers.each do |field| %>
+            <th><%= field %></th>
           <% end %>
         </tr>
       </thead>
@@ -13,8 +13,8 @@
       <tbody>
         <% observation.samples.each do |sample| %>
           <tr>
-            <% sample.response_data.each do |k, v| %>
-              <td><%= v %></td>
+            <% column_headers.each do |field| %>
+              <td><%= sample.response_data[field] %></td>
             <% end %>
           </tr>
         <% end %>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,6 +1,6 @@
 <div class="col-md-12">
   <h3>Data by Protocol</h3>
-  <% @by_protocol.each do |protocol| %>
+  <% @protocols.each do |protocol| %>
     <div class="panel panel-default">
       <!-- Protocol Header -->
       <div class="panel-heading">
@@ -11,7 +11,7 @@
       </div>
       <!-- Protocol Contents -->
       <div class="panel-body">
-        <%= render partial: "samples_table", locals: { observations: protocol.observations } %>
+        <%= render partial: "samples_table", locals: { observations: protocol.observations, column_headers: protocol.observations.first.sample_field_names } %>
       </div>
     </div>
   <% end %>

--- a/app/views/observations/index.html.erb
+++ b/app/views/observations/index.html.erb
@@ -1,40 +1,17 @@
 <div class="col-md-12">
-  <h3>
-    Observations by Site
-    <%= link_to "Download CSV", observations_path(nil, format: :csv), class: "btn btn-success btn-xs" %>
-  </h3>
-  <% @by_site.each do |site, observations| %>
+  <h3>Data by Protocol</h3>
+  <% @by_protocol.each do |protocol| %>
     <div class="panel panel-default">
+      <!-- Protocol Header -->
       <div class="panel-heading">
-        <h4><%= site %></h4>
+        <h4>
+          <%= protocol.title %>
+          <%= link_to "Download CSV", observation_path(protocol, format: "csv"), class: "btn btn-success btn-xs" %>
+        </h4>
       </div>
-        <div class="panel-body">
-          <% observations.each do |observation| %>
-          <h5>
-            <%= "Observation [Id: #{observation.id} Date: #{observation.date}]" %>
-            <%= link_to "Edit", edit_observation_path(observation), class: "btn btn-primary btn-xs" %>
-          </h5>
-          <table class="table table-striped table-bordered">
-            <thead>
-              <% observation.sample_field_names.each_with_index do |name, i| %>
-                <% break if i > 6 %>
-                <th><%= name %></th>
-              <% end %>
-              <th>Edit</th>
-              <th>Delete</th>
-            </thead>
-            <tbody>
-              <% observation.samples.each do |sample| %>
-                <tr>
-                  <% sample.response_data.each_with_index do |(k, v), i| %>
-                    <% break if i > 6 %>
-                      <td><%= v %></td>
-                  <% end %>
-                </tr>
-              <% end %>
-            </tbody>
-          </table>
-          <% end %>
+      <!-- Protocol Contents -->
+      <div class="panel-body">
+        <%= render partial: "samples_table", locals: { observations: protocol.observations } %>
       </div>
     </div>
   <% end %>

--- a/spec/controllers/observations_controller_spec.rb
+++ b/spec/controllers/observations_controller_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe ObservationsController, type: :controller do
   before do
     @property = Property.create(name: "Test Property")
     @site = Site.create(name: "Test Site", property: @property)
-    @protocol = SurveyProtocol.create(title: "Bees!")
+    @protocol = SurveyProtocol.create(title: "Bees!", sample_fields: [{label: "header 1"}, {label: "header 2"}] )
   end
 
+  let(:observation) { Observation.create(protocol: @protocol, site_id: @site.id) }
+  let(:csv_options) { {filename: "#{p}"}}
 
   it "accepts params" do
     post :create, observation: { "property_id" => @property.id, "site_id" => @site.id }
@@ -20,5 +22,13 @@ RSpec.describe ObservationsController, type: :controller do
   it "can view index" do
     get :index
     expect(response).to render_template :index
+  end
+
+  it "GET #show will export to CSV" do
+    expect(@controller).to receive(:send_data) {
+      @controller.render nothing: true
+    }
+    get :show, id: observation.protocol.id, format: :csv
+    expect(response.content_type).to eq "text/csv"
   end
 end

--- a/spec/fixtures/observations.yml
+++ b/spec/fixtures/observations.yml
@@ -1,13 +1,13 @@
 ---
 Observation_1:
   id: 1
-  protocol_id: 2
+  protocol_id: 3
   site_id: 4
   created_at: 2016-06-19 14:55:33.550992000 Z
   updated_at: 2016-06-19 14:55:33.550992000 Z
 Observation_2:
   id: 2
   site_id: 3
-  protocol_id: 3
+  protocol_id: 2
   created_at: 2016-06-19 14:55:35.689331000 Z
   updated_at: 2016-06-19 14:55:35.689331000 Z

--- a/spec/fixtures/survey_protocols.yml
+++ b/spec/fixtures/survey_protocols.yml
@@ -166,7 +166,7 @@ SurveyProtocol_2:
   created_at: 2016-06-19 05:56:58.079915000 Z
   updated_at: 2016-06-19 06:07:43.915508000 Z
   sample_fields:
-  - label: Surveyor names
+  - label: Surveyor Names
     field_type: text
     required: true
     field_options:


### PR DESCRIPTION
So finished up the minimal CSV download feature, should align more closely with expected excel spreadsheet format used by the staff. 

Also did a ton of refactoring, broke things into partials so the templating isn't as insane.

You'll also notice I went back to the weird chained method calls in 2 places (lines 7-9 in _sample_table.html.erb partial and line 9 in survey_protocols.rb model file).  This is because the Observation#sample_field_names method gives me the wrong set of column titles for the sample data, so I would get like 5 columns in the table header with 10+ columns of data in the table body.

I ran the following lines in rails console and what I get don't match up.

``` Ruby
SurveyProtocol.first.sample_fields.map { |field| field["label"] }
SurveyProtocol.first.observations.first.samples.first.response_data
```

The fields don't seem to match up, bit weird maybe I'm missing something?
Everything else seems alright, though.

<img width="1186" alt="screen shot 2016-07-13 at 10 22 55 pm" src="https://cloud.githubusercontent.com/assets/4479415/16826099/6baf44f4-4948-11e6-9544-ba290845dd1f.png">
