### PR TITLE
Add Link to Manage Protocol Page Addresses #80

### DIFF
--- a/app/views/survey_protocols/index.html.erb
+++ b/app/views/survey_protocols/index.html.erb
@@ -1,7 +1,10 @@
+<h2>Protocols</h2>
 <% @survey_protocols.each do |protocol| %>
-    <%= link_to protocol.title, [:edit, protocol] %>
+    <ul><%= link_to protocol.title, [:edit, protocol] %></ul>
     <br/>
 <% end  %>
 
 <br/>
-<%=link_to("Add Observations",new_observation_path)%>
+<hr/>
+<p><%=link_to("Add Observations",new_observation_path)%></p>
+<p><%=link_to("Add a New Protocol", new_survey_protocol_path)%></p>

--- a/app/views/survey_protocols/index.html.erb
+++ b/app/views/survey_protocols/index.html.erb
@@ -1,10 +1,10 @@
 <h2>Protocols</h2>
-<% @survey_protocols.each do |protocol| %>
-    <ul><%= link_to protocol.title, [:edit, protocol] %></ul>
-    <br/>
-<% end  %>
+<ul>
+  <% @survey_protocols.each do |protocol| %>
+      <li><%= link_to protocol.title, [:edit, protocol] %></li>
+  <% end  %>
+</ul>
 
-<br/>
 <hr/>
 <p><%=link_to("Add Observations",new_observation_path)%></p>
 <p><%=link_to("Add a New Protocol", new_survey_protocol_path)%></p>

--- a/spec/features/admin_links_to_new_protocol_spec.rb
+++ b/spec/features/admin_links_to_new_protocol_spec.rb
@@ -1,0 +1,10 @@
+require "rails_helper"
+
+RSpec.describe "User navigates to New Protocol page ", type: :feature do
+  scenario "the link to Manage Protocol page" do
+    visit survey_protocols_path
+    click_on "Add a New Protocol"
+
+    expect(current_path).to eq(new_survey_protocol_path)
+  end
+end


### PR DESCRIPTION
@h-m-m 
Add link to New Protocol from Manage Protocol page. 
Put Protocols in <ul> tags and added an hr for more clear distinction between the links.
Add a basic feature test.

Let me know if there are further navigation needs or updates you'd like to see.
Addresses #80 
