### PR TITLE
Fix admin page error when site has no property

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,4 +3,5 @@ class Site < ActiveRecord::Base
   has_many :subsites
 
   validates :name, presence: true
+  validates :property, presence: true
 end

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,4 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Site, type: :model do
+  it "model should fail validation if the property is missing" do
+    subject = Site.new
+    subject.name = "The Farm"
+    expect(subject.valid?).to equal false
+    expect(subject.errors.messages).to match({:property=>["can't be blank"]})
+  end
 end


### PR DESCRIPTION
This fixes issue #84. The page was erroring out because the requirement that a site has a property existed in the database, but did not exist in the Rails model. ActiveAdmin does not handle this situation well, but it is easy enough to fix.