### PR TITLE
Fix admin page error when site has no property 

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -3,4 +3,5 @@ class Site < ActiveRecord::Base
   has_many :subsites
 
   validates :name, presence: true
+  validates :property, presence: true
 end

--- a/spec/features/entry_submission_spec.rb
+++ b/spec/features/entry_submission_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe "submitting an individual entry", type: :feature do
-
-  let(:site) { Site.create! name: "test site", property_id: 22}
+  let(:property) { Property.create! }
+  let(:site) { Site.create! name: "test site", property_id: property.id}
 
   let(:sample) { observation.samples.create subsite_id: 33 }
   let(:observation ) { Observation.create site_id: site.id, protocol: protocol }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -1,4 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Site, type: :model do
+  it "model should fail validation if the property is missing" do
+    subject = Site.new
+    subject.name = "The Farm"
+    expect(subject.valid?).to equal false
+    expect(subject.errors.messages).to match({:property=>["can't be blank"]})
+  end
 end


### PR DESCRIPTION
This fixes issue #84. The page was erroring out because the requirement that a site has a property existed in the database, but did not exist in the Rails model. ActiveAdmin does not handle this situation well, but it is easy enough to fix.

I also had to fix a test now that there's stricter validation for sites belonging to properties.